### PR TITLE
Add PR CI workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,145 @@
+name: PR CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Setup Python & Validate Schemas
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies and validate
+        run: make validate
+
+  lint-typecheck:
+    name: Lint & Typecheck
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install Python lint dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff mypy
+      - name: Ruff
+        run: ruff .
+      - name: Mypy
+        run: mypy .
+      - name: Install Web dependencies
+        run: |
+          cd web
+          npm ci
+      - name: Web lint
+        run: |
+          cd web
+          npm run lint
+      - name: Web type-check
+        run: |
+          cd web
+          npm run type-check
+
+  ingest:
+    name: Ingest (dry-run)
+    runs-on: ubuntu-latest
+    needs: [lint-typecheck]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ingest/requirements.txt
+      - name: Run ingest
+        run: PR_CI=1 python ingest/run_ingest.py
+
+  enrich:
+    name: Enrich (dry-run)
+    runs-on: ubuntu-latest
+    needs: ingest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ingest/requirements.txt
+      - name: Run enrich
+        run: PR_CI=1 python enrich/run_enrich.py
+
+  scoring:
+    name: Scoring (dry-run)
+    runs-on: ubuntu-latest
+    needs: enrich
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ingest/requirements.txt
+      - name: Run scoring
+        run: PR_CI=1 python scoring/run_scoring.py
+
+  build-web:
+    name: Build Web (no deploy)
+    runs-on: ubuntu-latest
+    needs: scoring
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        run: |
+          cd web
+          npm ci
+      - name: Build and export
+        run: |
+          cd web
+          npm run build
+          npm run export

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -35,12 +35,12 @@ repos:
 
   # Pre-commit hooks per Node.js/TypeScript
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.1
+    rev: v3.1.0
     hooks:
       - id: prettier
-        types_or: [javascript, jsx, ts, tsx, json, css, scss, html, md, yaml]
+        types_or: [javascript, jsx, ts, tsx, json, css, scss, html, markdown, yaml]
         additional_dependencies:
-          - prettier@3.1.1
+          - prettier@3.1.0
 
   # ESLint per TypeScript/JavaScript
   - repo: https://github.com/pre-commit/mirrors-eslint
@@ -62,7 +62,6 @@ repos:
         name: PP100 Schema Validation
         entry: python scripts/validate_schemas.py
         language: system
-        types: [json, jsonl]
         pass_filenames: false
         always_run: true
         description: "Valida tutti i file in public/data/ contro gli schemi JSON"


### PR DESCRIPTION
## Summary
- add PR CI workflow that validates schemas, lints/types, runs ingest/enrich/scoring dry runs, and builds web without deploying
- fix pre-commit config types and Prettier version

## Testing
- `pre-commit run --config pre-commit-config.yaml --files .github/workflows/pr.yml pre-commit-config.yaml` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*
- `python - <<'PY'
import yaml
with open('.github/workflows/pr.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac776a546c83328ab2300d856d7022